### PR TITLE
MicroOptBuild

### DIFF
--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -25,7 +25,7 @@ class _HomeViewState extends State<HomeView> {
   void initState() {
     super.initState();
     // 👉 Esto asegura que se carguen los libros y listings al iniciar la app
-    Future.microtask(() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       final booksVM = Provider.of<BooksViewModel>(context, listen: false);
       booksVM.fetchBooks();
       booksVM.fetchPublishedListings();

--- a/lib/views/user_library/user_library_view.dart
+++ b/lib/views/user_library/user_library_view.dart
@@ -21,7 +21,7 @@ class _UserLibraryViewState extends State<UserLibraryView> with RouteAware {
   @override
   void initState() {
     super.initState();
-    Future.microtask(() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       context.read<BooksViewModel>().fetchUserListings();
     });
   }
@@ -40,14 +40,20 @@ class _UserLibraryViewState extends State<UserLibraryView> with RouteAware {
 
   @override
   void didPopNext() {
-    // Se llama cuando regresas a esta pantalla
-    context.read<BooksViewModel>().fetchUserListings();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        context.read<BooksViewModel>().fetchUserListings();
+      }
+    });
   }
 
   @override
   void didPush() {
-    // Se llama cuando la pantalla se muestra por primera vez o tras un push
-    context.read<BooksViewModel>().fetchUserListings();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        context.read<BooksViewModel>().fetchUserListings();
+      }
+    });
   }
 
   @override


### PR DESCRIPTION
## PR: Fix notifyListeners() During Build – Post-Frame Callbacks

###  Summary
This PR fixes a runtime issue caused by calling `notifyListeners()` during the widget build phase in `HomeView` and `UserLibraryView`. 

We replaced `Future.microtask(...)` with `WidgetsBinding.instance.addPostFrameCallback(...)` to ensure view model methods are called **after** the widget tree has been fully built.

### Affected Files
- `lib/views/home_view.dart`
- `lib/views/user_library/user_library_view.dart`

### Changes Made
#### HomeView
- Replaced:
  ```dart
  Future.microtask(() {
with:

  ```dart
WidgetsBinding.instance.addPostFrameCallback((_) {
  ```
Prevents premature calls to BooksViewModel.fetchBooks() and fetchPublishedListings().

###  UserLibraryView
Updated initState, didPush, and didPopNext lifecycle methods to use addPostFrameCallback.
Added if (mounted) safety check to prevent unwanted updates after widget disposal.

###  Benefit
Resolves runtime exceptions during widget build.
Aligns with Flutter lifecycle best practices.
Ensures safe and predictable state updates without risking frame drops or crashes.